### PR TITLE
[9.0] res config name get fix

### DIFF
--- a/openerp/addons/base/res/res_config.py
+++ b/openerp/addons/base/res/res_config.py
@@ -627,7 +627,7 @@ class res_config_settings(osv.osv_memory, res_config_module_installation_mixin):
         action_ids = act_window.search(cr, uid, [('res_model', '=', self._name)], context=context)
         name = self._name
         if action_ids:
-            name = act_window.read(cr, uid, action_ids[0], ['name'], context=context)['name']
+            name = act_window.read(cr, uid, [action_ids[0]], ['name'], context=context)[0]['name']
         return [(record.id, name) for record in self.browse(cr, uid , ids, context=context)]
 
     def get_option_path(self, cr, uid, menu_xml_id, context=None):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

name_get function needs to ensure that read passes the required
ids as a list, not a single value.  This is very important if
the method is inherited.