### PR TITLE
[L10N] Tax template name conflict (AU/NZ)

### DIFF
--- a/addons/l10n_nz/data/account.tax.template.csv
+++ b/addons/l10n_nz/data/account.tax.template.csv
@@ -1,9 +1,9 @@
 id,chart_template_id:id,name,sequence,description,type_tax_use,amount_type,amount,price_include,account_id:id,refund_account_id:id,tag_ids:id
 nz_tax_sale_15,l10n_nz_chart_template,Sale (15%),1,GST Sales,sale,percent,15,FALSE,nz_21310,nz_21310,tag_nz_tax_sale_15
 nz_tax_sale_inc_15,l10n_nz_chart_template,GST Inc Sale (15%),2,GST Inclusive Sales,sale,percent,15,TRUE,nz_21310,nz_21310,tag_nz_tax_sale_inc_15
-nz_tax_sale_0,l10n_nz_chart_template,Zero (Export) Sale,3,Zero Rated (Export) Sales,sale,percent,0,FALSE,nz_21310,nz_21310,tag_nz_tax_sale_0
+nz_tax_sale_0,l10n_nz_chart_template,Zero/Export (0%) Sale,3,Zero Rated (Export) Sales,sale,percent,0,FALSE,nz_21310,nz_21310,tag_nz_tax_sale_0
 nz_tax_purchase_15,l10n_nz_chart_template,Purch (15%),1,GST Purchases,purchase,percent,15,FALSE,nz_21330,nz_21330,tag_nz_tax_purchase_15
 nz_tax_purchase_inc_15,l10n_nz_chart_template,GST Inc Purch (15%),2,GST Inclusive Purchases,purchase,percent,15,TRUE,nz_21330,nz_21330,tag_nz_tax_purchase_inc_15
-nz_tax_purchase_0,l10n_nz_chart_template,Zero Rated Purch,3,Zero Rated Purchases,purchase,percent,0,FALSE,nz_21330,nz_21330,tag_nz_tax_purchase_0
-nz_tax_purchase_taxable_import,l10n_nz_chart_template,Purch (Taxable Imports),4,Purchase (Taxable Imports) - Tax Paid Separately,purchase,percent,0,FALSE,nz_21330,nz_21330,tag_nz_tax_purchase_taxable_import
-nz_tax_purchase_gst_only,l10n_nz_chart_template,GST Only on Imports,5,GST Only on Imports,purchase,percent,100000000,TRUE,nz_21330,nz_21330,tag_nz_tax_purchase_gst_only
+nz_tax_purchase_0,l10n_nz_chart_template,Zero/Import (0%) Purch,3,Zero Rated Purchases,purchase,percent,0,FALSE,nz_21330,nz_21330,tag_nz_tax_purchase_0
+nz_tax_purchase_taxable_import,l10n_nz_chart_template,Purch (Imports Taxable),4,Purchase (Taxable Imports) - Tax Paid Separately,purchase,percent,0,FALSE,nz_21330,nz_21330,tag_nz_tax_purchase_taxable_import
+nz_tax_purchase_gst_only,l10n_nz_chart_template,GST Only – Imports,5,GST Only on Imports,purchase,percent,100000000,TRUE,nz_21330,nz_21330,tag_nz_tax_purchase_gst_only


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Rectify name conflict in tax templates between nz and au chart of accounts.

Fixes #12600